### PR TITLE
Setup: Installation: Fixed build instruction capitalization

### DIFF
--- a/src/setup/installation.md
+++ b/src/setup/installation.md
@@ -45,7 +45,7 @@ Once you have obtained the source, you may build the server and
 client.
 
 ```shell
-$ go get github.com/NetAuth/Netauth/cmd/...
+$ go get github.com/NetAuth/NetAuth/cmd/...
 ```
 
 Your compiled binaries will be in `$GOPATH/bin/`.  As with all Go


### PR DESCRIPTION
`Netauth` -> `NetAuth`.  
Was causing build to fail.